### PR TITLE
allow custom snapshot name without automatic date suffix, fixes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ can be used to cleanup snapshots as they get too old... for example
 Usage
 -----
 
-    usage: zfs-snapshot-all [-hnv] <name> [[pool1] pool2 ...]
+    usage: zfs-snapshot-all [-hnx] <name> [[pool1] pool2 ...]
 
     recursively snapshot all zpools
 
@@ -59,9 +59,15 @@ Usage
         # zfs-snapshot-all bar pool1 pool2
         snapshot zpools pool1 and pool2 with the prefix bar
 
+        # zfs-snapshot-all -x baz pool3
+        snapshot zpool pool3 with the *exact* snapshot name 'baz'
+
+
     options
         -h             print this message and exit
         -n             dry-run, don't actually create snapshots
+        -x             don't automatically append the date in epoch to
+                       the snapshot name
 
 License
 -------

--- a/zfs-snapshot-all
+++ b/zfs-snapshot-all
@@ -9,7 +9,7 @@
 usage() {
 	local prog=${0##*/}
 	cat <<-EOF
-	usage: $prog [-hn] <name> [[pool1] pool2 ...]
+	usage: $prog [-hnx] <name> [[pool1] pool2 ...]
 
 	recursively snapshot all zpools
 
@@ -20,17 +20,25 @@ usage() {
 	    # $prog bar pool1 pool2
 	    snapshot zpools pool1 and pool2 with the prefix bar
 
+	    # $prog -x baz pool3
+	    snapshot zpool pool3 with the *exact* snapshot name 'baz'
+
+
 	options
 	    -h             print this message and exit
 	    -n             dry-run, don't actually create snapshots
+	    -x             don't automatically append the date in epoch to
+	                   the snapshot name
 	EOF
 }
 
 dryrun=false
-while getopts 'hn' option; do
+date=true
+while getopts 'hnx' option; do
 	case "$option" in
 		h) usage; exit 0;;
 		n) dryrun=true;;
+		x) date=false;;
 		*) usage; exit 1;;
 	esac
 done
@@ -56,7 +64,12 @@ fi
 now=$(date +%s)
 code=0
 for zpool in "${pools[@]}"; do
-	snapshot=${zpool}@${name}_${now}
+	if $date; then
+		snapshot=${zpool}@${name}_${now}
+	else
+		snapshot=${zpool}@${name}
+	fi
+
 	echo -n "zfs snapshot -r $snapshot"
 	if $dryrun; then
 		echo ' # dry-run: no action taken'


### PR DESCRIPTION
```
# ./zfs-snapshot-all -xn "custom_prefix_$(date +%Y%m%d_%H%M)" 
zfs snapshot -r goliath@custom_prefix_20180816_1722 # dry-run: no action taken
zfs snapshot -r zones@custom_prefix_20180816_1722 # dry-run: no action taken
```